### PR TITLE
Fixed: Error while saving does not throw.

### DIFF
--- a/Sources/GarnishTheme/Persistence/GarnishThemePersistence.swift
+++ b/Sources/GarnishTheme/Persistence/GarnishThemePersistence.swift
@@ -53,7 +53,7 @@ public class GarnishThemePersistence {
         
         if context.hasChanges {
             do {
-                try? context.save()
+                try context.save()
             } catch {
                 throw GarnishThemeError.coreDataError(error)
             }


### PR DESCRIPTION
Fixed the warning where saving the GarnishThemePersistence context does not throw an error because `try?` is used instead of `try`.