### PR TITLE
Remove GarnishTheme from GarnishPlayground target

### DIFF
--- a/Playground/GarnishPlayground.xcodeproj/project.pbxproj
+++ b/Playground/GarnishPlayground.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		2D361B622E42A2F000567EAB /* Garnish in Frameworks */ = {isa = PBXBuildFile; productRef = 2D361B612E42A2F000567EAB /* Garnish */; };
-		2D4667982E43FCEC00DD41ED /* GarnishTheme in Frameworks */ = {isa = PBXBuildFile; productRef = 2D4667972E43FCEC00DD41ED /* GarnishTheme */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,7 +28,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D361B622E42A2F000567EAB /* Garnish in Frameworks */,
-				2D4667982E43FCEC00DD41ED /* GarnishTheme in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -81,7 +79,6 @@
 			name = GarnishPlayground;
 			packageProductDependencies = (
 				2D361B612E42A2F000567EAB /* Garnish */,
-				2D4667972E43FCEC00DD41ED /* GarnishTheme */,
 			);
 			productName = GarnishPlayground;
 			productReference = 2D361B3A2E42A23D00567EAB /* GarnishPlayground.app */;
@@ -385,11 +382,6 @@
 		2D361B612E42A2F000567EAB /* Garnish */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Garnish;
-		};
-		2D4667972E43FCEC00DD41ED /* GarnishTheme */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2D361B602E42A2F000567EAB /* XCLocalSwiftPackageReference "../../Garnish" */;
-			productName = GarnishTheme;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
- remove the GarnishTheme package product reference from the Xcode project
- unlink GarnishTheme from the target Frameworks build phase
- keep Garnish as the only linked framework for the playground target